### PR TITLE
bot.Say fixes

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -234,6 +234,12 @@ func (bb *BasicBot) Say(msg string) error {
 	if "" == msg {
 		return errors.New("BasicBot.Say: msg was empty.")
 	}
+
+	// check if message is too large for IRC
+	if len(msg) > 512 {
+		return errors.New("BasicBot.Say: msg exceeded 512 bytes")
+	}
+	
 	_, err := bb.conn.Write([]byte(fmt.Sprintf("PRIVMSG #%s %s\r\n", bb.Channel, msg)))
 	if nil != err {
 		return err

--- a/bot.go
+++ b/bot.go
@@ -240,7 +240,7 @@ func (bb *BasicBot) Say(msg string) error {
 		return errors.New("BasicBot.Say: msg exceeded 512 bytes")
 	}
 	
-	_, err := bb.conn.Write([]byte(fmt.Sprintf("PRIVMSG #%s %s\r\n", bb.Channel, msg)))
+	_, err := bb.conn.Write([]byte(fmt.Sprintf("PRIVMSG #%s :%s\r\n", bb.Channel, msg)))
 	if nil != err {
 		return err
 	}


### PR DESCRIPTION
Hello. I was [reading your article about building Twitch bots in Golang](https://dev.to/foresthoffman/building-a-twitchtv-chat-bot-with-go---part-1-i3k) and was following along with the code, using it for a miniature project I am working on. Everything has been super useful, but I noticed two tiny issues with the bot.Say function and I am sharing my discovery here.

Firstly, [Twitch has a maximum limit of 500 characters for it's IRC service](https://discuss.dev.twitch.tv/t/message-character-limit/7793). It may be lower for un-modded accounts, but I figured attaching a limit check would be good enough. This may need some additional work or changes to check for the real limit.

Second, messages with spaces weren't sending for me. I checked the IRC logs and a single colon was the reason why. This was confusing at first but printing whole IRC messages cleared up the issue.

Hopefully this helps, let me know if there is anything else I should do.